### PR TITLE
Use web middleware group on routes

### DIFF
--- a/src-php/Routes/web.php
+++ b/src-php/Routes/web.php
@@ -3,7 +3,7 @@
 /**
  * Blog Routes
  */
-Route::prefix('blog')->name('blog.')->group(function () {
+Route::middleware('web')->prefix('blog')->name('blog.')->group(function () {
     Route::get('/', 'Dewsign\NovaBlog\Http\Controllers\BlogController@index')->name('index');
     Route::get('{category}', 'Dewsign\NovaBlog\Http\Controllers\BlogController@list')->name('list');
     Route::get('{category}/{article}', 'Dewsign\NovaBlog\Http\Controllers\BlogController@show')->name('show');


### PR DESCRIPTION
Routes from this nova-blog package were not being registered with the web middleware in the host application.  Manually adding the web middleware group here.