### PR TITLE
only return blog posts which have categories

### DIFF
--- a/src-php/Http/Controllers/BlogController.php
+++ b/src-php/Http/Controllers/BlogController.php
@@ -22,6 +22,7 @@ class BlogController extends Controller
     public function index()
     {
         $articles = app(config('novablog.models.article', Article::class))::includeRepeaters()->active()
+            ->has('categories')
             ->orderBy('published_date', 'desc')
             ->paginate(config('novablog.pageSize', 12));
 


### PR DESCRIPTION
Since we can only route to blog article if it has a category, it makes sense to only return articles with categories from the index method.