### PR TITLE
Index paginated pages in sitemap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.0.0",
         "laravel/framework": ">=5.0.0",
-        "maxfactor/support": "^2.0.0",
+        "maxfactor/support": "^2.3.0",
         "benjaminhirsch/nova-slug-field": "^1.0",
         "dewsign/nova-repeater-blocks": "^1.2.0",
         "epartment/nova-dependency-container": "^1.1",

--- a/src-php/Http/Controllers/BlogController.php
+++ b/src-php/Http/Controllers/BlogController.php
@@ -37,7 +37,7 @@ class BlogController extends Controller
         ->with('articles', $articles)
         ->with('categories', $categories)
         ->with('page', [
-            'canonical' => route('blog.index')
+            'canonical' => \Maxfactor::urlWithQuerystring(route('blog.index'), $allowedParameters = 'page=[^1]')
         ]);
     }
 

--- a/src-php/Models/Category.php
+++ b/src-php/Models/Category.php
@@ -59,4 +59,14 @@ class Category extends Model implements Sortable
             ],
         ]);
     }
+
+    /**
+     * Set the canonical url including pagination querystring
+     *
+     * @return string
+     */
+    public function baseCanonical()
+    {
+        return \Maxfactor::urlWithQuerystring(url()->current(), $allowedParameters = 'page=[^1]');
+    }
 }

--- a/src-php/NovaBlog.php
+++ b/src-php/NovaBlog.php
@@ -17,19 +17,47 @@ class NovaBlog
     private static function addIndex($sitemap)
     {
         $sitemap->add(route('blog.index'));
+
+        $articles = app(config('novablog.models.article', Article::class))::includeRepeaters()
+            ->active()
+            ->has('categories')
+            ->orderBy('published_date', 'desc')
+            ->paginate(config('novablog.pageSize', 12))
+            ->setPath(route('blog.index'));
+
+        for ($page = 2; $page <= $articles->lastPage(); $page ++) {
+            $sitemap->add($articles->url($page));
+        }
     }
 
     private static function addCategories($sitemap)
     {
-        app(config('novablog.models.category', Category::class))::active()->has('articles')->get()->each(function ($category) use ($sitemap) {
-            $sitemap->add(route('blog.list', $category));
-        });
+        app(config('novablog.models.category', Category::class))::active()
+            ->has('articles')
+            ->get()
+            ->each(function ($category) use ($sitemap) {
+                $sitemap->add(route('blog.list', $category));
+
+                $articles = $category
+                    ->articles()
+                    ->active()
+                    ->orderBy('published_date', 'desc')
+                    ->paginate(config('novablog.pageSize', 12))
+                    ->setPath(route('blog.list', $category));
+
+                for ($page = 2; $page <= $articles->lastPage(); $page ++) {
+                    $sitemap->add($articles->url($page));
+                }
+            });
     }
 
     private static function addArticles($sitemap)
     {
-        app(config('novablog.models.article', Article::class))::active()->has('categories')->get()->each(function ($article) use ($sitemap) {
-            $sitemap->add(route('blog.show', [$article->primaryCategory, $article]));
-        });
+        app(config('novablog.models.article', Article::class))::active()
+            ->has('categories')
+            ->get()
+            ->each(function ($article) use ($sitemap) {
+                $sitemap->add(route('blog.show', [$article->primaryCategory, $article]));
+            });
     }
 }


### PR DESCRIPTION
When using the `NovaBlog::sitemap` helper method to generate sitemap entries, include paginated index pages. Uses the standard page size defined in the config to match what the user is shown.

resolves #13 